### PR TITLE
Replace "{archive_file_path}" placeholder in ar_cmd to fix build problem with 1.6.6

### DIFF
--- a/stino/pyarduino/arduino_compiler.py
+++ b/stino/pyarduino/arduino_compiler.py
@@ -312,7 +312,8 @@ class Compiler(object):
             core_changed = True
             cmds = []
             for obj_path in self.core_obj_paths:
-                cmd = ar_cmd.replace('{object_file}', obj_path)
+                cmd = ar_cmd.replace('{object_file}', obj_path) \
+                            .replace('{archive_file_path}', core_archive_path)
                 cmds.append(cmd)
             self.build_files.append(core_archive_path)
             self.file_cmds_dict[core_archive_path] = cmds


### PR DESCRIPTION
build was broken with 1.6.6 because the pattern for core.a has a new placeholder ("{archive_file_path}")

Is this the right fork to contribute to?
